### PR TITLE
fix multiSelectKey

### DIFF
--- a/src/components/SlVueTreeNext/types.ts
+++ b/src/components/SlVueTreeNext/types.ts
@@ -48,7 +48,7 @@ export interface SlVueTreeProps<T> {
     parentContext?: Context<T>
     rootContext?: any
     allowToggleBranch?: boolean
-    multiSelectKey? : MultiSelectKey[]
+    multiselectKey? : MultiSelectKey[]
     scrollAreaHeight?: number
     maxScrollSpeed?: number
 }


### PR DESCRIPTION
The `multiselectKey` prop in `SlVueTreeProps` was incorrectly written as `multiSelectKey` (with an uppercase "S").  

# Description  
Corrected the prop name.  

# How to test?  
If you click on a node in the tree while holding the `Ctrl` key, you will be able to select multiple nodes by default.  
